### PR TITLE
changes for desktop view for showing 4 cards in a row

### DIFF
--- a/blocks/car-card/car-card.css
+++ b/blocks/car-card/car-card.css
@@ -3,7 +3,7 @@
   margin: 0;
   padding: 0;
   display: grid;
-  grid-template-columns: repeat(3, calc((100% - 16px * 3) / 3));
+  grid-template-columns: repeat(auto-fill, minmax(288px, 1fr));
   gap: 1rem;
 }
 
@@ -84,6 +84,7 @@
     gap: 0.25rem;
     font-size: var(--font-size-xs-alt);
     border-right: 1px solid var(--border-color);
+    padding-right: var(--spacing-xxxs);
   }
 
   span.seats {
@@ -95,6 +96,7 @@
     width: 2rem;
     height: 2rem;
     margin: auto;
+    opacity: 0.8;
   }
 }
 
@@ -130,4 +132,29 @@
 .car-card-button-container a {
   margin: 0;
   width: 100%;
+}
+
+@media (width >=768px) {
+  .car-detail-container {
+    padding: var(--spacing-xs) var(--spacing-xs) var(--spacing-s) var(--spacing-xs);
+  }
+}
+
+@media (width >=1024px) {
+  .section.car-card-4 {
+    .car-cards-wrapper {
+      grid-template-columns: repeat(4, calc((100% - 16px * 3) / 4));
+
+      .car-feature {
+        span {
+          font-size: var(--font-size-xxs);
+        }
+
+        span::before {
+          width: 30px;
+          height: 30px;
+        }
+      }
+    }
+  }
 }

--- a/blocks/car-card/car-card.js
+++ b/blocks/car-card/car-card.js
@@ -58,8 +58,8 @@ function buildCardTemplate(cardObj) {
           <h3>${cardObj?.year} ${cardObj?.modelName}</h3>
           <img data-offer-id="${cardObj?.offerId}" class="car-card-heart" src="../../icons/heart.svg" alt="Wishlist Icon">
         </div>
-        <img class="car-card-image" src="${imageLink}" alt="BMW 4 Series">
-        <p class="car-card-type">${cardObj?.type || ''}</p>
+        <img class="car-card-image" src="${imageLink}" alt="car offers image">
+         ${cardObj?.type ? `<p class="car-card-type">${cardObj?.type}</p>` : ''}
         <p class="car-card-description">${cardObj?.carDescription || ''}</p>
       <div>
       `;


### PR DESCRIPTION
Added changes for showing 4 cards in desktop
It requires to add a class - **car-card-4** in the section to show the 4 cards in a row

![image](https://github.com/user-attachments/assets/8c8380c5-24d0-49f3-aaf6-692e687ec76d)


Test URLs:

- Before: https://main--mmsg-oly--aemsites.hlx.live/
- After: https://car-card--mmsg-oly--aemsites.hlx.live/
