### PR TITLE
Added 'xwalk/max-cells' config in eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,5 +15,13 @@ module.exports = {
     'linebreak-style': ['error', 'unix'], // enforce unix linebreaks
     'no-param-reassign': [2, { props: false }], // allow modifying properties of param
     'import/prefer-default-export': 'error',
+    'xwalk/max-cells': [
+      'error',
+      {
+        '*': 4,
+        // 'a-specific-model': 4,
+        // 'another-specific-model': 2,
+      },
+    ],
   },
 };


### PR DESCRIPTION
Added 'xwalk/max-cells' config in eslintrc.js to avoid the linting errors.


Test URLs:

- Before: https://main--mmsg-oly--aemsites.hlx.live/
- After: https://eslint-override--mmsg-oly--aemsites.hlx.live/
