### PR TITLE
Adding the initial version of the NL-calculator block

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
         '*': 4,
         // 'a-specific-model': 4,
         // 'another-specific-model': 2,
+        'nl-calculator': 10,
       },
     ],
   },

--- a/component-models.json
+++ b/component-models.json
@@ -742,6 +742,13 @@
       {
         "component": "richtext",
         "valueType": "string",
+        "name": "apiCalculatorDetails",
+        "label": "Text",
+        "value": ""
+      },
+      {
+        "component": "richtext",
+        "valueType": "string",
         "name": "titleWithDescription",
         "label": "Text",
         "value": ""
@@ -789,16 +796,30 @@
         "value": "Lease Term"
       },
       {
+        "component": "richtext",
+        "valueType": "string",
+        "name": "carViewDescription",
+        "label": "Text",
+        "value": ""
+      }
+      {
         "component": "text",
         "valueType": "string",
-        "name": "formLabelCar_Salary",
+        "name": "formLabelYou_Salary",
         "label": "Salary label",
         "value": ""
       },
       {
         "component": "richtext",
         "valueType": "string",
-        "name": "calculatorDescription",
+        "name": "aboutViewDescription",
+        "label": "Text",
+        "value": ""
+      },
+      {
+        "component": "richtext",
+        "valueType": "string",
+        "name": "resultsViewDescription",
         "label": "Text",
         "value": ""
       }

--- a/component-models.json
+++ b/component-models.json
@@ -801,7 +801,7 @@
         "name": "carViewDescription",
         "label": "Text",
         "value": ""
-      }
+      },
       {
         "component": "text",
         "valueType": "string",


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:

- Before: https://main--mmsg-oly--aemsites.hlx.live/
- After: https://nl-calculator--mmsg-oly--aemsites.hlx.live/
